### PR TITLE
Fix import in readme, prettier usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sanity Query Helper
 [![CircleCI](https://circleci.com/gh/staccx/sanityQueryHelper.svg?style=svg)](https://circleci.com/gh/staccx/sanityQueryHelper)
 [![Coverage Status](https://coveralls.io/repos/github/staccx/sanityQueryHelper/badge.svg?branch=master)](https://coveralls.io/github/staccx/sanityQueryHelper?branch=master)
+
 ## Description
 
 
@@ -11,39 +12,41 @@
 ## Usage
 
 Immutable. All functions are chainable (except for send) and return a new helper.
-```
-import SanityQueryHelper, {comparisons} from "sanityQueryHelper"
+```js
+import SanityQueryHelper, {comparisons} from "sanity-query-helper"
 
-const sanityHelper = new SanityQueryHelper({sanityOptions: {projectId: "project-id", dataset: "myDataSet", useCdn: true})
+const sanityHelper = new SanityQueryHelper({
+  sanityOptions: {
+    projectId: "project-id",
+    dataset: "myDataSet",
+    useCdn: true
+  }
+})
 
 // Create query
 
-//Filters
+// Filters
 const filter = sanityHelper
-.ofType("post")
-.withFilter("releaseDate") // .compare("releaseDate", comparisons.greaterOrEqualTo, 1979)
-.greaterOrEqualTo(1979)
-.send()
-.then(useMyData) // 👈 response from sanity
+  .ofType("post")
+  .withFilter("releaseDate") // .compare("releaseDate", comparisons.greaterOrEqualTo, 1979)
+  .greaterOrEqualTo(1979)
+  .send()
+  .then(useMyData) // 👈 response from sanity
 
-
-
-
-//Picks aka Projections
+// Picks aka Projections
 filter
- .pick("title")
- .send()
- .then(useMyData) // 👈 response with projection
+  .pick("title")
+  .send()
+  .then(useMyData) // 👈 response with projection
 
-//Select
+//  Select
 const select = projection
-.select(0, 10)
-.send()
-.then(data => doStuff(data)) // 👈 response will have 10 first posts (if that many exists)
+  .select(0, 10)
+  .send()
+  .then(data => doStuff(data)) // 👈 response will have 10 first posts (if that many exists)
 
-//Order by
-
+// Order by
 select
-.orderBy(releaseYear)
-.send(orderedData => use(orderedData))
+  .orderBy(releaseYear)
+  .send(orderedData => use(orderedData))
 ```


### PR DESCRIPTION
This PR fixes a few issues with the readme:
  - Incorrect `import` statement (wrong module name)
  - Formats code as JS
  - Fix a syntax error due to missing `}`
  - Indents and wraps code for better readability